### PR TITLE
Cicd build improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 -   setup crate in crate.io
 -   updated readme
 -   update cargo.toml with keyword and category words for crates.io
+-   package name changed from `cracker` to `ck-cracker` for publishing
 
 [v0.11.0] 2024-11-20
 -------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+[v0.11.1] 2024-11-26
+-------------------
+
+-   setup crate in crate.io
+-   updated readme
+-   update cargo.toml with keyword and category words for crates.io
+
 [v0.11.0] 2024-11-20
 -------------------
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cracker"
-include = ["src/**/*", "README.md", "CHANGELOG.md","LISCENSE", "fonts/**/*"]
+include = ["src/**/*", "README.md", "CHANGELOG.md","LISCENSE", "fonts/**/*", "Cargo.toml"]
 default-run = "ck"
 version = "0.11.1"
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,13 @@
 [package]
 name = "cracker"
-include = ["src/**/*", "README.md"]
+include = ["src/**/*", "README.md", "CHANGELOG.md","LISCENSE", "fonts/**/*"]
 default-run = "ck"
 version = "0.11.0"
 edition = "2021"
 license = "GPL-3.0"
+reademe = "README.md"
+repository = "https://github.com/lloydbond/cracker"
+homepage = "https://github.com/lloydbond/cracker"
 description = "Cracker is a simple, fast, and plain task runner. Designed with the idea of supporting as many task tools as possible."
 authors = ["Lloyd Bond"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cracker"
 include = ["src/**/*", "README.md", "CHANGELOG.md","LISCENSE", "fonts/**/*"]
 default-run = "ck"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "GPL-3.0"
 reademe = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cracker"
+name = "ck-cracker"
 include = ["src/**/*", "README.md", "CHANGELOG.md","LISCENSE", "fonts/**/*", "Cargo.toml"]
 default-run = "ck"
 version = "0.11.1"
@@ -10,7 +10,7 @@ repository = "https://github.com/lloydbond/cracker"
 homepage = "https://github.com/lloydbond/cracker"
 description = "Cracker is a simple, fast, and plain task runner. Designed with the idea of supporting as many task tools as possible."
 keywords = ["makefile","tasks","taskrunner"]
-categories = ["command-line-utilities", "development-tools::build-tools"]
+categories = ["command-line-utilities", "development-tools::build-utils"]
 authors = ["Lloyd Bond"]
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ reademe = "README.md"
 repository = "https://github.com/lloydbond/cracker"
 homepage = "https://github.com/lloydbond/cracker"
 description = "Cracker is a simple, fast, and plain task runner. Designed with the idea of supporting as many task tools as possible."
+keywords = ["makefile","tasks","taskrunner"]
+categories = ["command-line-utilities", "development-tools::build-tools"]
 authors = ["Lloyd Bond"]
 
 [[bin]]

--- a/README.md
+++ b/README.md
@@ -13,8 +13,16 @@ Be sure to add $HOME/.cargo/bin/ to your environment PATH variable.
 -  *Windows Subsystem for Linux (WSL)
 
 \* untested, should work.
+## Installation Methods
+### Install with cargo
+If you haven't isntalled `cargo` yet, now's a good time.
+Follow the cargo install instructions [here](https://doc.rust-lang.org/cargo/getting-started/installation.html)
+Then run from your terminal.
+```bash
+cargo install ck-cracker
+```
 
-## Manual Installation
+### Manual Installation
 
 Clone the repository:
 


### PR DESCRIPTION
-   setup crate in crate.io
-   updated readme
-   update cargo.toml with keyword and category words for crates.io
-   package name changed from `cracker` to `ck-cracker` for publishing